### PR TITLE
Fix undefined database seeder function

### DIFF
--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+use App\Models\Post;
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Tag::factory()->count(10)->create();
+        Post::all()->each(function ($post) {
+            $post->tags()->attach(Tag::inRandomOrder()->limit(\rand(1, 3))->pluck('id'));
+        });
+    }
+}


### PR DESCRIPTION
Call `rand()` from the global namespace to resolve an 'Undefined function' error within the `Database\Seeders` namespace.

---
<a href="https://cursor.com/background-agent?bcId=bc-951394bd-6ee0-4597-ba74-cee385004e8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-951394bd-6ee0-4597-ba74-cee385004e8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

